### PR TITLE
[FEAT] Define external dependencies

### DIFF
--- a/FindAMentor/Application/AppDelegate.swift
+++ b/FindAMentor/Application/AppDelegate.swift
@@ -30,6 +30,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RootInstaller {
     return true
   }
 
+  func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    self.store.dependencies.authManager.resumeAuthentication(from: url, with: options)
+  }
+
 }
 
 extension AppDelegate {

--- a/FindAMentor/Dependencies/Auth0Manager.swift
+++ b/FindAMentor/Dependencies/Auth0Manager.swift
@@ -1,0 +1,71 @@
+//
+//  Auth0Manager.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 12/04/2020.
+//
+
+import Foundation
+import Auth0
+import Hydra
+
+/// Protocol that completely defines and masks the Auth0 API.
+protocol Auth0Manager {
+  /// Function that begins the authentication flow
+  /// - parameter scope: The scope of this specific authentication flow
+  func startAuthentication(with scope: String) -> Promise<Credentials>
+
+  /// Function tha begins the logout process for the user
+  func logout() -> Promise<Void>
+
+  /// Resumes the login process after the user logged in
+  /// - parameter from: The URL that is asked to be opened
+  /// - parameter options: options passed to the app
+  func resumeAuthentication(from url: URL, with options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool
+}
+
+/// Implementation for the Auth0 Manager
+class Auth0ManagerImpl: Auth0Manager {
+
+  /// the backend endpoint
+  var audience: String
+
+  /// Default initializer
+  init(audience: String) {
+    self.audience = audience
+  }
+
+  func startAuthentication(with scope: String) -> Promise<Credentials> {
+    return Promise<Credentials>(in: .background) { [unowned self] resolve, reject, _ in
+      // is it safe to use unowned here because self refers to the manager and
+      // the manager is kept alive by the Katana Store. No risk to access it when nil
+
+      Auth0.webAuth().scope(scope).audience(self.audience).start { result in
+        switch result {
+        case .failure(let error):
+          reject(error)
+        case .success(let credentials):
+          resolve(credentials)
+        }
+      }
+    }
+  }
+
+  func logout() -> Promise<Void> {
+    return Promise<Void>(in: .background) { resolve, reject, _ in
+      Auth0.webAuth().clearSession(federated: false) { successful in
+        guard successful else {
+          return reject(Models.Auth0Error.logoutFailed)
+        }
+        resolve(())
+      }
+    }
+  }
+
+  func resumeAuthentication(from url: URL, with options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool {
+    return Auth0.resumeAuth(url, options: options)
+  }
+
+
+
+}

--- a/FindAMentor/Dependencies/BackendManager.swift
+++ b/FindAMentor/Dependencies/BackendManager.swift
@@ -1,0 +1,83 @@
+//
+//  BackendManager.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 12/04/2020.
+//
+
+import Foundation
+import Hydra
+
+/// This protocol defines the public interface of the Backend Manager
+/// It contains all the functions that masks the APIs call
+protocol BackendManager {
+
+  // MARK: - Mentors
+
+  /// Retrieve the list of mentors
+  func getMentors() -> Promise<[Models.User]>
+
+  /// Send a request for mentorship from a user to another.
+  /// - parameter from: the requesting user identifier
+  /// - parameter to: the mentor identifier
+  /// - parameter requestInfo: the set of informations that are attached to the request
+  // TODO: improve the requestInfo object
+  func requestMentorship(from userId: String, to mentorId: String, requestInfo: String) -> Promise<Void>
+
+  /// Retrieve the list of mentorhips for a specific mentor
+  /// - parameter mentorId: the identifier of the mentor
+  func mentorships(for mentorId: String) -> Promise<Models.Mentorship>
+
+  /// Updates a mentorship with a new set of application info
+  /// - parameter applicationId: the identifier of the application
+  /// - parameter applicationInfo: a the model of the application
+  func updateMentorshipStatus(for applicationId: String, with applicationInfo: Models.Mentorship) -> Promise<Void>
+
+
+  // MARK: - Users
+
+  /// Retrieve the model of the user currently logged in
+  func getCurrentUser() -> Promise<Models.User>
+
+  /// Retrieve the model of the user given a specific id
+  /// - parameter with: The identifier of the user
+  func getUser(with id: String) -> Promise<Models.User>
+
+  /// Updates the model of the user, given a new model.
+  /// This method can be used to update the goals of the user or any profile information
+  /// - parameter with: the new Model for the user
+  func updateUser(with model: Models.User) -> Promise<Void>
+
+}
+
+class BackendManagerImpl: BackendManager {
+  func getMentors() -> Promise<[Models.User]> {
+    fatalError("Not implemented yet")
+  }
+
+  func requestMentorship(from userId: String, to mentorId: String, requestInfo: String) -> Promise<Void> {
+    fatalError("Not implemented yet")
+  }
+
+  func mentorships(for mentorId: String) -> Promise<Models.Mentorship> {
+    fatalError("Not implemented yet")
+  }
+
+  func updateMentorshipStatus(for applicationId: String, with applicationInfo: Models.Mentorship) -> Promise<Void> {
+    fatalError("Not implemented yet")
+  }
+
+  func getCurrentUser() -> Promise<Models.User> {
+    fatalError("Not implemented yet")
+  }
+
+  func getUser(with id: String) -> Promise<Models.User> {
+    fatalError("Not implemented yet")
+  }
+
+  func updateUser(with model: Models.User) -> Promise<Void> {
+    fatalError("Not implemented yet")
+  }
+
+
+}

--- a/FindAMentor/Dependencies/DependenciesContainer.swift
+++ b/FindAMentor/Dependencies/DependenciesContainer.swift
@@ -11,17 +11,36 @@ class DependenciesContainer:
   SideEffectDependencyContainer,
   NavigationProvider
 {
+
+  // Use the right backend url in Debug and in Release
+  #if DEBUG
+  static let backendURL: String = "http://https://api-staging.codingcoach.io/"
+  #else
+  static let backendURL: String = "https://https://api.codingcoach.io/"
+  #endif
+
   // The function that let the dependencies to dispatch other Dispatchable
   var dispatch: PromisableStoreDispatch
+
   // The function that let the dependencies to retrieve the most updated version of the State
   var getState: GetState
+
   // The dependencies responsible to handle the navigation in the app
   var navigator: Navigator
+
+  // the manager that hide the interactions with the backend
+  var backendManager: BackendManager
+
+  // the manager that handles the login and logout operation
+  var authManager: Auth0Manager
 
   // Initializer of all the dependencies
   required init(dispatch: @escaping PromisableStoreDispatch, getState: @escaping GetState) {
     self.dispatch = dispatch
     self.getState = getState
+
     self.navigator = Navigator()
+    self.backendManager = BackendManagerImpl()
+    self.authManager = Auth0ManagerImpl(audience: Self.backendURL)
   }
 }

--- a/FindAMentor/Models/Errors.swift
+++ b/FindAMentor/Models/Errors.swift
@@ -1,0 +1,13 @@
+//
+//  Errors.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 12/04/2020.
+//
+
+import Foundation
+extension Models {
+  enum Auth0Error: Error {
+    case logoutFailed
+  }
+}

--- a/FindAMentor/Models/Mentorship.swift
+++ b/FindAMentor/Models/Mentorship.swift
@@ -1,0 +1,29 @@
+//
+//  Mentorship.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 12/04/2020.
+//
+
+import Foundation
+
+extension Models {
+  /// Model for the mentorhips
+  struct Mentorship: Codable {
+    /// Possible statuses of a request
+    enum Status: String, Codable {
+      case accepted
+      case pending
+      case rejected
+    }
+
+    /// The current status of the request
+    var status: Status
+
+    /// The description of the request
+    var description: String
+
+    /// The reason why the mentor has asked for the mentorship
+    var reason: String
+  }
+}

--- a/FindAMentor/Models/User.swift
+++ b/FindAMentor/Models/User.swift
@@ -1,0 +1,18 @@
+//
+//  UserModel.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 12/04/2020.
+//
+
+import Foundation
+
+/// Namespace for the Models
+enum Models {
+
+  /// User model
+  // TODO: improve the model from the backend documentation
+  struct User: Codable {
+
+  }
+}

--- a/FindAMentor/State/AppState.swift
+++ b/FindAMentor/State/AppState.swift
@@ -6,4 +6,18 @@ import Katana
 /// to work at runtime
 struct AppState: State, Codable {
 
+  enum CodingKeys: String, CodingKey {
+    case userState
+    case mentorsState
+    case loginState
+  }
+
+  // MARK: - Persisted Slices
+  var loginState: LoginState = LoginState()
+  var userState: UserState = UserState()
+  var mentorsState: MentorsState = MentorsState()
+
+  // MARK: - Non persisted Slices
+  var environmentState: EnvironmentState = EnvironmentState()
+
 }

--- a/FindAMentor/State/EnvironmentState.swift
+++ b/FindAMentor/State/EnvironmentState.swift
@@ -1,0 +1,89 @@
+//
+//  EnvironmentState.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 11/04/2020.
+//
+
+import Foundation
+import Katana
+import UserNotifications
+
+extension AppState {
+  /// This structure contains the environment information
+  /// for the current session of the user.
+  struct EnvironmentState: State {
+    var keyboardState: KeyboardState = KeyboardState()
+    var pushNotificationState: PushNotificationState = PushNotificationState()
+  }
+
+  // MARK: - Keyboard State
+  
+  /// This struct contains the current state of the keyboard.
+  /// The keyboard can be hidden or visible.
+  /// When visible, it is presented with some animation options
+  /// that need to imitated by the rest of the UI for a smooth animation
+  struct KeyboardState: State, Equatable {
+      static let defaultAnimationDuration: Double = 0.3
+      static let defaultAnimationCurve: UIView.AnimationCurve = .easeInOut
+
+      enum Visibility: Equatable {
+        case hidden
+        case visible(frame: CGRect)
+      }
+
+      var visibility: Visibility = .hidden
+      var animationDuration = defaultAnimationDuration
+      var animationCurve = defaultAnimationCurve
+
+      /// The current height of the keyboard. 0 if the keyboard is hidden
+      var height: CGFloat {
+        switch self.visibility {
+        case .hidden:
+          return 0
+        case .visible(let frame):
+          return frame.height
+        }
+      }
+  }
+
+  // MARK: - Push Notification State
+
+  /// This structure contains the current state of the Push Notification
+  /// It also define an enumeration with all the supported notification types
+  struct PushNotificationState: State, Equatable {
+
+    var pushNotificationStatuses: [PushNotificationType: UNAuthorizationStatus] = [:]
+
+    /// Enumeration with all the supported type. This is required because the
+    /// UNAuthorizationOptions does not conform to Hashable, therefore it
+    /// has to be converted from an Obj-C type to a Swift type.
+    enum PushNotificationType: Int {
+      case alert
+      case badge
+      case carPlay
+      case criticalAlert
+      case provisional
+      case sound
+
+      init(from option: UNAuthorizationOptions) {
+        switch option {
+        case .alert:
+          self = .alert
+        case .badge:
+          self = .badge
+        case .carPlay:
+          self = .carPlay
+        case .criticalAlert:
+          self = .criticalAlert
+        case .provisional:
+          self = .provisional
+        case .sound:
+          self = .sound
+        default:
+          fatalError("Cannot create a PushNotificationType")
+        }
+      }
+    }
+  }
+}

--- a/FindAMentor/State/LoginState.swift
+++ b/FindAMentor/State/LoginState.swift
@@ -1,0 +1,21 @@
+//
+//  LoginState.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 11/04/2020.
+//
+
+import Foundation
+import Katana
+
+extension AppState {
+
+  /// This structure contains all the informations related to the user's login.
+  /// The backend is using Auth0 for authentication.
+  struct LoginState: State, Codable {
+    // TODO: Study Auth0 to understand what to put here.
+    // In general we would like to keep the token and everything we need to
+    // eventually refresh it
+
+  }
+}

--- a/FindAMentor/State/MentorsState.swift
+++ b/FindAMentor/State/MentorsState.swift
@@ -1,0 +1,20 @@
+//
+//  MentorsState.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 11/04/2020.
+//
+
+import Foundation
+import Katana
+
+extension AppState {
+
+  /// This is the slice of state that populates the mentors
+  /// list
+  struct MentorsState: State, Codable {
+    // TODO: study the mentors API to understand the models
+    // If the mentors ends up being very complex, consider to split them
+    // in multiple slices.
+  }
+}

--- a/FindAMentor/State/UserState.swift
+++ b/FindAMentor/State/UserState.swift
@@ -1,0 +1,20 @@
+//
+//  UserState.swift
+//  FindAMentor
+//
+//  Created by Riccardo Cipolleschi on 11/04/2020.
+//
+
+import Foundation
+import Katana
+
+extension AppState {
+
+  /// This structure contains all the informations related to the user.
+  struct UserState: State, Codable {
+    // TODO: study the backend API
+    // the user state will be very complex, given that it should handle
+    // mentors, mentorees, goals, requests, ...
+    // The suggestion is to split it in different slices.
+  }
+}

--- a/Podfile
+++ b/Podfile
@@ -7,4 +7,6 @@ target 'FindAMentor' do
 
   pod 'Katana', '~> 3.0'
   pod 'Tempura', '~> 4.0'
+  pod 'BonMot', '~> 5.5'
+  pod 'PinLayout', '~> 1.8'
 end

--- a/Podfile
+++ b/Podfile
@@ -9,4 +9,5 @@ target 'FindAMentor' do
   pod 'Tempura', '~> 4.0'
   pod 'BonMot', '~> 5.5'
   pod 'PinLayout', '~> 1.8'
+  pod 'Auth0', '~> 1.19'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,19 @@
 PODS:
+  - Auth0 (1.23.0):
+    - JWTDecode
+    - SimpleKeychain
   - BonMot (5.5.1)
   - HydraAsync (1.2.1)
+  - JWTDecode (2.4.1)
   - Katana (3.1.0):
     - HydraAsync (~> 1.2)
   - PinLayout (1.8.13)
+  - SimpleKeychain (0.11.1)
   - Tempura (4.3.0):
     - Katana (< 4, >= 3.0)
 
 DEPENDENCIES:
+  - Auth0 (~> 1.19)
   - BonMot (~> 5.5)
   - Katana (~> 3.0)
   - PinLayout (~> 1.8)
@@ -15,19 +21,25 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
+    - Auth0
     - BonMot
     - HydraAsync
+    - JWTDecode
     - Katana
     - PinLayout
+    - SimpleKeychain
     - Tempura
 
 SPEC CHECKSUMS:
+  Auth0: a0e48dc2562c33e82f3aaf3bf400f4b4071a1d79
   BonMot: 0d179476725af81f622a6d9f660f43048070016a
   HydraAsync: 8f2ab62d57e140b4ca587ae0f66e1eb04e8e6965
+  JWTDecode: 4bd4da0cdf0f8154fd467fa48499f34ec057fb88
   Katana: caa2adb661a386f9a993a15845841dc2c9b083aa
   PinLayout: e41a50260a76508b7a7fcee8955c76639adc69bc
+  SimpleKeychain: 0c657949c7afff92337d2ff64052d5eb5c53823e
   Tempura: d38c2d982864d9dbca6b11a519e8b00024d04abd
 
-PODFILE CHECKSUM: 6374573bee81062db9563a8830bf5329d3eca12a
+PODFILE CHECKSUM: 2b3366d83ceb8d259efca771d2f43515526ae2f0
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,25 +1,33 @@
 PODS:
+  - BonMot (5.5.1)
   - HydraAsync (1.2.1)
   - Katana (3.1.0):
     - HydraAsync (~> 1.2)
+  - PinLayout (1.8.13)
   - Tempura (4.3.0):
     - Katana (< 4, >= 3.0)
 
 DEPENDENCIES:
+  - BonMot (~> 5.5)
   - Katana (~> 3.0)
+  - PinLayout (~> 1.8)
   - Tempura (~> 4.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
+    - BonMot
     - HydraAsync
     - Katana
+    - PinLayout
     - Tempura
 
 SPEC CHECKSUMS:
+  BonMot: 0d179476725af81f622a6d9f660f43048070016a
   HydraAsync: 8f2ab62d57e140b4ca587ae0f66e1eb04e8e6965
   Katana: caa2adb661a386f9a993a15845841dc2c9b083aa
+  PinLayout: e41a50260a76508b7a7fcee8955c76639adc69bc
   Tempura: d38c2d982864d9dbca6b11a519e8b00024d04abd
 
-PODFILE CHECKSUM: de1d2849e1a076f31d292de1356a704f320a1d72
+PODFILE CHECKSUM: 6374573bee81062db9563a8830bf5329d3eca12a
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
This PR adds the basic skeleton of the two dependencies we have towards external services:
* Auth0
* the coding coach backend.

The PR defines the APIs and connect them with the rest of the app.
However, we are missing:

* Configuration for the HTTP (allow arbitrary load)
* Configuration of the Auth0 data (waiting to receive the staging information)
* Actual implementation of the API.